### PR TITLE
レスポンスをあるべき形に修正

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -35,7 +35,9 @@ class UserController @Inject() (
   }
 
   def list = Action.async {
-    dbClientV2.list.map(res => Ok(toJson(res)))
+    dbClientV2.list
+      .map(res => Ok(toJson(res)))
+      .recover(_ => InternalServerError)
   }
 
   def find(id: String) = Action.async { _ =>
@@ -45,6 +47,7 @@ class UserController @Inject() (
         case Some(v) => Ok(toJson(v))
         case None    => NotFound
       }
+      .recover(_ => InternalServerError)
   }
 
   def postV2 = Action.async(parse.json) { req =>
@@ -54,6 +57,7 @@ class UserController @Inject() (
         invalid => Future(BadRequest),
         user => dbClientV2.put(user).map(const(Ok))
       )
+      .recover(_ => InternalServerError)
   }
 
   def update(id: String) = Action.async(parse.json) { req =>
@@ -67,9 +71,13 @@ class UserController @Inject() (
             case _       => Future(BadRequest)
           }
       )
+      .recover(_ => InternalServerError)
   }
 
   def delete(id: String) = Action.async {
-    dbClientV2.delete(id).map(const(NoContent))
+    dbClientV2
+      .delete(id)
+      .map(const(NoContent))
+      .recover(_ => InternalServerError)
   }
 }

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -60,8 +60,12 @@ class UserController @Inject() (
     req.body
       .validate[UserUpdateRequest]
       .fold(
-        invalid => Future(BadRequest),
-        req => dbClientV2.update(id, req).map(const(Ok))
+        invalid => Future(NotFound),
+        updateReq =>
+          dbClientV2.find(id).flatMap {
+            case Some(_) => dbClientV2.update(id, updateReq).map(const(Ok))
+            case _       => Future(BadRequest)
+          }
       )
   }
 

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -3,6 +3,7 @@ package controllers.user
 import javax.inject.Inject
 import domain.{User, UserUpdateRequest}
 import infra.dbclients.{UserDBClient, UserDBClientV2}
+import play.api.libs.json.Json.toJson
 import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.Future
@@ -34,14 +35,14 @@ class UserController @Inject() (
   }
 
   def list = Action.async {
-    dbClientV2.list.map(res => Ok(res.toString))
+    dbClientV2.list.map(res => Ok(toJson(res)))
   }
 
   def find(id: String) = Action.async { _ =>
     dbClientV2
       .find(id)
       .map {
-        case Some(v) => Ok(v.toString)
+        case Some(v) => Ok(toJson(v))
         case None    => NotFound
       }
   }
@@ -51,7 +52,7 @@ class UserController @Inject() (
       .validate[User]
       .fold(
         invalid => Future(BadRequest),
-        user => dbClientV2.put(user).map(res => Ok(res.toString))
+        user => dbClientV2.put(user).map(const(Ok))
       )
   }
 
@@ -60,11 +61,11 @@ class UserController @Inject() (
       .validate[UserUpdateRequest]
       .fold(
         invalid => Future(BadRequest),
-        req => dbClientV2.update(id, req).map(res => Ok(res.toString))
+        req => dbClientV2.update(id, req).map(const(Ok))
       )
   }
 
   def delete(id: String) = Action.async {
-    dbClientV2.delete(id).map(res => Ok(res.toString))
+    dbClientV2.delete(id).map(const(NoContent))
   }
 }

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -38,7 +38,12 @@ class UserController @Inject() (
   }
 
   def find(id: String) = Action.async { _ =>
-    dbClientV2.find(id).map(res => Ok(res.toString))
+    dbClientV2
+      .find(id)
+      .map {
+        case Some(v) => Ok(v.toString)
+        case None    => NotFound
+      }
   }
 
   def postV2 = Action.async(parse.json) { req =>

--- a/app/controllers/user/RequestConverter.scala
+++ b/app/controllers/user/RequestConverter.scala
@@ -1,7 +1,8 @@
 package controllers.user
 
 import domain.{User, UserUpdateRequest}
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
+import play.api.libs.json.{JsPath, Json, Reads, Writes}
 
 /** Json converter for user endpoint
   */
@@ -10,4 +11,10 @@ object RequestConverter {
   implicit val userReads: Reads[User] = Json.reads[User]
   implicit val userUpdateRequestReads: Reads[UserUpdateRequest] =
     Json.reads[UserUpdateRequest]
+
+  implicit val userWrites: Writes[User] = (
+    (JsPath \ "id").write[String] and
+      (JsPath \ "name").write[String] and
+      (JsPath \ "age").write[Int]
+  )(unlift(User.unapply))
 }

--- a/app/infra/dbclients/UserDBClientV2.scala
+++ b/app/infra/dbclients/UserDBClientV2.scala
@@ -85,7 +85,6 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) {
       .transform(const((): Unit), identity)
   }
 
-  // fixme upsertになってしまっているので、存在しないIDはエラーにする
   def update(id: String, u: UserUpdateRequest): Future[Unit] = {
     val updatedValues =
       List(

--- a/app/infra/dbclients/UserDBClientV2.scala
+++ b/app/infra/dbclients/UserDBClientV2.scala
@@ -53,12 +53,15 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) {
       )
   }
 
-  def find(id: String): Future[User] = {
+  def find(id: String): Future[Option[User]] = {
     val key = Map("user_id" -> toAttS(id)).asJava
     val req = GetItemRequest.builder().tableName(table).key(key).build()
     client
       .getItem(req)
-      .map(res => convertToUser(res.item()))
+      .map(res =>
+        if (res.item().isEmpty) None
+        else Some(convertToUser(res.item()))
+      )
   }
 
   def put(user: User): Future[Unit] = {

--- a/app/infra/dbclients/UserDBClientV2.scala
+++ b/app/infra/dbclients/UserDBClientV2.scala
@@ -1,31 +1,26 @@
 package infra.dbclients
 
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-
 import software.amazon.awssdk.services.dynamodb.model.{
   AttributeAction,
   AttributeValue,
   AttributeValueUpdate,
   DeleteItemRequest,
-  DeleteItemResponse,
-  DynamoDbException,
   GetItemRequest,
-  GetItemResponse,
   PutItemRequest,
-  PutItemResponse,
   ScanRequest,
-  ScanResponse,
-  UpdateItemRequest,
-  UpdateItemResponse
+  UpdateItemRequest
 }
 
 import java.util.concurrent.CompletableFuture
 import domain.{User, UserUpdateRequest}
 import javax.inject.Inject
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
 import scala.jdk.FutureConverters.CompletionStageOps
-import java.util.{Map => JavaMap}
+import java.util.{Map => JavaMap, List => JavaList}
+import scala.Function.const
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /** user db client
   */
@@ -42,39 +37,53 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) {
   ): JavaMap[T, U] =
     arg.asJava
 
+  implicit def JavaListToScalaList[T](
+      arg: JavaList[T]
+  ): List[T] = arg.asScala.toList
+
   val table = "users"
 
-  def list: Future[ScanResponse] = {
+  def list: Future[List[User]] = {
     val req = ScanRequest.builder().tableName(table).build()
-    client.scan(req)
+    client
+      .scan(req)
+      .map(
+        _.items()
+          .map(convertToUser(_))
+      )
   }
 
-  def find(id: String): Future[GetItemResponse] = {
+  def find(id: String): Future[User] = {
     val key = Map("user_id" -> toAttS(id)).asJava
-    val req =
-      GetItemRequest.builder().tableName(table).key(key).build()
-    client.getItem(req)
+    val req = GetItemRequest.builder().tableName(table).key(key).build()
+    client
+      .getItem(req)
+      .map(res => convertToUser(res.item()))
   }
 
-  def put(user: User): Future[PutItemResponse] = {
+  def put(user: User): Future[Unit] = {
     val item = Map(
       "user_id" -> toAttS(user.id),
       "user_name" -> toAttS(user.name),
       "user_age" -> toAttN(user.age)
     )
 
-    val req =
-      PutItemRequest.builder().tableName(table).item(item).build()
-    client.putItem(req)
+    val req = PutItemRequest.builder().tableName(table).item(item).build()
+    client
+      .putItem(req)
+      .transform(const((): Unit), identity)
   }
 
-  def delete(id: String): Future[DeleteItemResponse] = {
-    val key = Map("user_id" -> toAttS(id)).asJava
+  def delete(id: String): Future[Unit] = {
+    val key = Map("user_id" -> toAttS(id))
     val req = DeleteItemRequest.builder().tableName(table).key(key).build()
-    client.deleteItem(req)
+    client
+      .deleteItem(req)
+      .transform(const((): Unit), identity)
   }
 
-  def update(id: String, u: UserUpdateRequest): Future[UpdateItemResponse] = {
+  // fixme upsertになってしまっているので、存在しないIDはエラーにする
+  def update(id: String, u: UserUpdateRequest): Future[Unit] = {
     val updatedValues =
       List(
         ("user_name", u.name),
@@ -98,14 +107,24 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) {
         .key(key)
         .attributeUpdates(updatedValues)
         .build()
-    client.updateItem(req)
+    client
+      .updateItem(req)
+      .transform(const((): Unit), identity)
+  }
+
+  private def convertToUser(item: JavaMap[String, AttributeValue]): User = {
+    User(
+      item.get("user_id").s(),
+      item.get("user_name").s(),
+      item.get("user_age").n().toInt
+    )
   }
 
   private def toAttS(v: String): AttributeValue =
     AttributeValue.builder().s(v).build()
 
   private def toAttN(v: Int): AttributeValue =
-    AttributeValue.builder().s(v.toString).build()
+    AttributeValue.builder().n(v.toString).build()
 
   private def toUpdateAttS(
       v: String
@@ -126,5 +145,4 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) {
       .action(AttributeAction.PUT)
       .build()
   }
-
 }


### PR DESCRIPTION
## 変更点

- レスポンスをJSONもしくはステータスコードのみで返すように変更
    - 拾いきれないエラーは500で返す
- Get時ユーザーが見つからない場合にエラーが出ていたのを修正
- Patch時にユーザが存在しなくてもアップデートできていたのを修正
- Number型のAttribute作成メソッドのバグを修正


## issue

close #5 
close #6