### PR TITLE
DDBのupdateのロジックをリファクタリング

### DIFF
--- a/app/controllers/user/RequestConverter.scala
+++ b/app/controllers/user/RequestConverter.scala
@@ -1,7 +1,6 @@
 package controllers.user
 
-import controllers.user.vo.UserUpdateRequest
-import domain.User
+import domain.{User, UserUpdateRequest}
 import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
 

--- a/app/controllers/user/UserControllerV2.scala
+++ b/app/controllers/user/UserControllerV2.scala
@@ -5,12 +5,12 @@ import controllers.user.RequestConverter.{
   userUpdateRequestReads,
   userWrites
 }
-import controllers.user.vo.UserUpdateRequest
 import domain.{
   InvalidUpdateInfoError,
   JsValueConvertError,
   User,
-  UserNotFoundError
+  UserNotFoundError,
+  UserUpdateRequest
 }
 import infra.dbclients.v2.UserDBClientV2
 import play.api.Logging

--- a/app/controllers/user/UserControllerV2.scala
+++ b/app/controllers/user/UserControllerV2.scala
@@ -6,7 +6,12 @@ import controllers.user.RequestConverter.{
   userWrites
 }
 import controllers.user.vo.UserUpdateRequest
-import domain.{JsValueConvertError, User, UserNotFoundError}
+import domain.{
+  InvalidUpdateInfoError,
+  JsValueConvertError,
+  User,
+  UserNotFoundError
+}
 import infra.dbclients.v2.UserDBClientV2
 import play.api.Logging
 import play.api.libs.json.{JsValue, Reads}
@@ -71,9 +76,9 @@ class UserControllerV2 @Inject() (
     } yield Ok
 
     future.recover {
-      case _: JsValueConvertError => BadRequest
-      case _: UserNotFoundError   => NotFound
-      case _                      => InternalServerError
+      case _: JsValueConvertError | _: InvalidUpdateInfoError => BadRequest
+      case _: UserNotFoundError                               => NotFound
+      case _                                                  => InternalServerError
     }
   }
 

--- a/app/domain/UserError.scala
+++ b/app/domain/UserError.scala
@@ -2,4 +2,7 @@ package domain
 
 final case class UserNotFoundError(message: String) extends RuntimeException
 
+final case class InvalidUpdateInfoError(message: String)
+    extends RuntimeException
+
 final case class JsValueConvertError(message: String) extends RuntimeException

--- a/app/domain/UserUpdateRequest.scala
+++ b/app/domain/UserUpdateRequest.scala
@@ -1,4 +1,4 @@
-package controllers.user.vo
+package domain
 
 case class UserUpdateRequest(
     name: Option[String],

--- a/app/infra/dbclients/v2/TypeConverter.scala
+++ b/app/infra/dbclients/v2/TypeConverter.scala
@@ -1,0 +1,23 @@
+package infra.dbclients.v2
+
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.Future
+import scala.jdk.FutureConverters.CompletionStageOps
+import java.util.{List => JavaList, Map => JavaMap}
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, MapHasAsJava}
+
+object TypeConverter {
+  implicit def javaFutureToScalaFuture[T](
+      arg: CompletableFuture[T]
+  ): Future[T] =
+    arg.asScala
+
+  implicit def scalaMapToJavaMap[T, U](
+      arg: Map[T, U]
+  ): JavaMap[T, U] =
+    arg.asJava
+
+  implicit def JavaListToScalaList[T](
+      arg: JavaList[T]
+  ): List[T] = arg.asScala.toList
+}

--- a/app/infra/dbclients/v2/UserDBClientV2.scala
+++ b/app/infra/dbclients/v2/UserDBClientV2.scala
@@ -1,7 +1,11 @@
 package infra.dbclients.v2
 
-import controllers.user.vo.UserUpdateRequest
-import domain.{InvalidUpdateInfoError, User, UserNotFoundError}
+import domain.{
+  InvalidUpdateInfoError,
+  User,
+  UserNotFoundError,
+  UserUpdateRequest
+}
 import play.api.Logging
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._

--- a/app/infra/dbclients/v2/UserDBClientV2.scala
+++ b/app/infra/dbclients/v2/UserDBClientV2.scala
@@ -1,39 +1,24 @@
 package infra.dbclients.v2
 
 import controllers.user.vo.UserUpdateRequest
-import domain.{User, UserNotFoundError}
+import domain.{InvalidUpdateInfoError, User, UserNotFoundError}
 import play.api.Logging
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
 
-import java.util.concurrent.CompletableFuture
-import java.util.{List => JavaList, Map => JavaMap}
+import java.util.{Map => JavaMap}
 import javax.inject.Inject
 import scala.Function.const
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
-import scala.jdk.FutureConverters.CompletionStageOps
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+// AWS SDK for Javaをスムーズに利用するためにimplicit conversionを利用
+import infra.dbclients.v2.TypeConverter._
 
 /** user db client
   */
 class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) extends Logging {
-
-  // AWS SDK for Javaをスムーズに利用するためにimplicit conversionを利用
-  implicit def javaFutureToScalaFuture[T](
-      arg: CompletableFuture[T]
-  ): Future[T] =
-    arg.asScala
-
-  implicit def scalaMapToJavaMap[T, U](
-      arg: Map[T, U]
-  ): JavaMap[T, U] =
-    arg.asJava
-
-  implicit def JavaListToScalaList[T](
-      arg: JavaList[T]
-  ): List[T] = arg.asScala.toList
-
   val table = "users"
 
   def list: Future[List[User]] = {
@@ -43,7 +28,7 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) extends Logging {
       .scan(req)
       .map(
         _.items()
-          .map(convertToUser(_))
+          .map(toUser(_))
       )
   }
 
@@ -59,7 +44,7 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) extends Logging {
           logger.error(msg)
           throw UserNotFoundError(msg)
         }
-        convertToUser(res.item())
+        toUser(res.item())
       }
   }
 
@@ -87,21 +72,7 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) extends Logging {
   }
 
   def update(id: String, u: UserUpdateRequest): Future[Unit] = {
-    val updatedValues =
-      List(
-        ("user_name", u.name),
-        ("user_age", u.age)
-      )
-        .filter(_._2.isDefined)
-        // fixme 例外になるケースを追加する
-        .map(_ match {
-          case (s, Some(v: String)) if s == "user_name" =>
-            (s -> (toUpdateAttS(v)))
-          case (s, Some(v: Int)) if s == "user_age" =>
-            (s -> (toUpdateAttN(v)))
-        })
-        .toMap
-
+    val updatedValues = toUpdatedValues(u)
     val key = Map("user_id" -> toAttS(id)).asJava
     logger.info(
       s"DDB update user start. id=${id}. updateValue=${updatedValues}"
@@ -119,12 +90,44 @@ class UserDBClientV2 @Inject() (client: DynamoDbAsyncClient) extends Logging {
       .transform(const((): Unit), identity)
   }
 
-  private def convertToUser(item: JavaMap[String, AttributeValue]): User = {
+  private def toUser(item: JavaMap[String, AttributeValue]): User = {
     User(
       item.get("user_id").s(),
       item.get("user_name").s(),
       item.get("user_age").n().toInt
     )
+  }
+
+  private def toUpdatedValues(
+      u: UserUpdateRequest
+  ): Map[String, AttributeValueUpdate] = {
+
+    val updatedValues =
+      List(
+        ("user_name", u.name),
+        ("user_age", u.age)
+      )
+        .filter(_._2.isDefined)
+        .map(_ match {
+          case (s, Some(v: String)) if s == "user_name" =>
+            (s -> (toUpdateAttS(v)))
+          case (s, Some(v: Int)) if s == "user_age" =>
+            (s -> (toUpdateAttN(v)))
+          case _ => {
+            val msg = s"invalid information. request=${u}"
+            logger.error(msg)
+            throw InvalidUpdateInfoError(msg)
+          }
+        })
+        .toMap
+
+    if (updatedValues.size == 0) {
+      val msg = s"request does not have valid information. request=${u}"
+      logger.error(msg)
+      throw InvalidUpdateInfoError(msg)
+    }
+
+    updatedValues
   }
 
   private def toAttS(v: String): AttributeValue =


### PR DESCRIPTION
## 変更点

- DDBのupdateのロジックをリファクタリング
    - メソッド名を変更
- コントローラーでのエラーハンドリングの追加
- update用のVOをドメイン層へ移動
- DDBクライアントのimplicit conversionを別ファイルへ移動


## issue
close #29 